### PR TITLE
Replace deprecated curly bracket access syntax

### DIFF
--- a/src/Parser/Input.php
+++ b/src/Parser/Input.php
@@ -14,7 +14,7 @@ class Input
 
     public function getChar(): ?string
     {
-        $char = $this->value{$this->currentPosition} ?? null;
+        $char = $this->value[$this->currentPosition] ?? null;
         $this->currentPosition++;
         return $char;
     }


### PR DESCRIPTION
This library emits `Deprecated: Array and string offset access syntax with curly braces is deprecated` message when used on PHP 7.4.
https://www.php.net/manual/en/migration74.deprecated.php

P.S. Thanks for this library, it was exactly what I was looking for.